### PR TITLE
Iss2 fix unsafe member access fib route

### DIFF
--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,5 +1,5 @@
 // util function that computes the fibonacci numbers
-export function fibonacci(n): number {
+export default function fibonacci(n): number {
   if (n < 0) {
     return -1;
   } else if (n == 0) {

--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,5 +1,5 @@
 // util function that computes the fibonacci numbers
-export default function fibonacci(n) {
+export function fibonacci(n): number {
   if (n < 0) {
     return -1;
   } else if (n == 0) {
@@ -10,3 +10,5 @@ export default function fibonacci(n) {
 
   return fibonacci(n - 1) + fibonacci(n - 2);
 }
+
+module.exports = fibonacci;

--- a/src/fibRoute.ts
+++ b/src/fibRoute.ts
@@ -3,7 +3,7 @@
 import fibonacci from "./fib";
 
 export default (req, res) => {
-  const { num } = req.params;
+  const num: string = req.params;
 
   const fibN = fibonacci(parseInt(num));
   let result = `fibonacci(${num}) is ${fibN}`;


### PR DESCRIPTION
Added module exports at the end of file
and assigned a type to the const num holding request body information
num is used elsewhere and succeeding issues are caused by not assigning a type.