### PR TITLE
specify as a number

### DIFF
--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,5 +1,5 @@
 // util function that computes the fibonacci numbers
-export default function fibonacci(n) {
+export default function fibonacci(n: number) {
   if (n < 0) {
     return -1;
   } else if (n == 0) {


### PR DESCRIPTION
fixed typing error with  implicit 'any' datatype on variable with number requirement